### PR TITLE
Add HUBen frontend scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+# logs
+yarn.lock
+npm-debug.log*
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # huben
-Cyberhub
+
+This repository contains the frontend for HUBen, a small platform for cybersecurity analysis for SMBs.
+
+## Getting started
+
+```bash
+cd cyberhub/huben-frontend
+npm install
+npm run dev
+```

--- a/cyberhub/huben-frontend/index.html
+++ b/cyberhub/huben-frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="no">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>HUBen</title>
+  </head>
+  <body class="bg-gray-50 text-gray-900">
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/cyberhub/huben-frontend/package.json
+++ b/cyberhub/huben-frontend/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "huben-frontend",
+  "version": "0.0.1",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "@tailwindcss/postcss": "^4.0.0",
+    "autoprefixer": "^10.4.14",
+    "postcss": "^8.4.21",
+    "tailwindcss": "^4.0.0",
+    "vite": "^4.5.0"
+  }
+}

--- a/cyberhub/huben-frontend/postcss.config.js
+++ b/cyberhub/huben-frontend/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    '@tailwindcss/postcss': {},
+    autoprefixer: {},
+  },
+}

--- a/cyberhub/huben-frontend/src/App.jsx
+++ b/cyberhub/huben-frontend/src/App.jsx
@@ -1,0 +1,27 @@
+import React from 'react'
+
+function App() {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-tr from-white to-gray-100 px-4">
+      <div className="bg-white p-8 rounded-3xl shadow-2xl w-full max-w-md transition">
+        <h1 className="text-3xl font-bold mb-4 text-gray-900">🔐 HUBen – Cybersikkerhet for SMB</h1>
+        <p className="text-gray-600 mb-6">Skriv inn e-postadressen din for å sjekke om den er lekket i kjente databrudd.</p>
+        <form className="space-y-4">
+          <input
+            type="email"
+            placeholder="din@bedrift.no"
+            className="w-full px-4 py-3 rounded-xl border border-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-600 text-sm"
+          />
+          <button
+            type="submit"
+            className="w-full bg-blue-600 text-white py-3 rounded-xl font-semibold hover:bg-blue-700 transition"
+          >
+            🔍 Sjekk e-post
+          </button>
+        </form>
+      </div>
+    </div>
+  )
+}
+
+export default App

--- a/cyberhub/huben-frontend/src/index.css
+++ b/cyberhub/huben-frontend/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/cyberhub/huben-frontend/src/main.jsx
+++ b/cyberhub/huben-frontend/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App.jsx'
+import './index.css'
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+)

--- a/cyberhub/huben-frontend/tailwind.config.js
+++ b/cyberhub/huben-frontend/tailwind.config.js
@@ -1,0 +1,7 @@
+export default {
+  content: ['./index.html', './src/**/*.{js,jsx,ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/cyberhub/huben-frontend/vite.config.js
+++ b/cyberhub/huben-frontend/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+})


### PR DESCRIPTION
## Summary
- scaffold HUBen frontend under `cyberhub/huben-frontend`
- configure Vite and Tailwind CSS
- implement simple landing page
- add usage instructions

## Testing
- `npm install`
- `npm run dev` (starts Vite server)

------
https://chatgpt.com/codex/tasks/task_e_68797adcff6c8332ba9f2769e7177a19